### PR TITLE
Signupでinputが空だと登録できないように変更

### DIFF
--- a/backend/db/repository.go
+++ b/backend/db/repository.go
@@ -44,7 +44,7 @@ func (r *UserDBRepository) AddUser(ctx context.Context, user domain.User) (int64
 
 func (r *UserDBRepository) GetUser(ctx context.Context, id int64) (domain.User, error) {
 	row := r.QueryRowContext(ctx, "SELECT * FROM users WHERE id = ?", id)
-
+	//userを全部取ってくる
 	var user domain.User
 	return user, row.Scan(&user.ID, &user.Name, &user.Password, &user.Balance)
 }

--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -166,6 +166,7 @@ func (h *Handler) Login(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 
+	//リクエストのuserID をlogging
 	user, err := h.UserRepo.GetUser(ctx, req.UserID)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
@@ -455,6 +456,10 @@ func (h *Handler) AddBalance(c echo.Context) error {
 	req := new(addBalanceRequest)
 	if err := c.Bind(req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
+	}
+
+	if req.Balance < 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, "Balance cannot be negative")
 	}
 
 	userID, err := getUserID(c)

--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -144,6 +144,18 @@ func (h *Handler) Register(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 
+	if req.Name == "" && req.Password == ""{
+		return echo.NewHTTPError(http.StatusBadRequest, "Name and Password are required")
+	}
+	
+	if req.Name == "" {
+        return echo.NewHTTPError(http.StatusBadRequest, "Name is required")
+    }
+
+    if req.Password == "" {
+        return echo.NewHTTPError(http.StatusBadRequest, "Password is required")
+    }
+
 	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
@@ -153,7 +165,7 @@ func (h *Handler) Register(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
-
+	fmt.Printf("Registered user: %s", req.Name)
 	return c.JSON(http.StatusOK, registerResponse{ID: userID, Name: req.Name})
 }
 

--- a/frontend/simple-mercari-web/src/components/Signup/Signup.tsx
+++ b/frontend/simple-mercari-web/src/components/Signup/Signup.tsx
@@ -32,7 +32,8 @@ export const Signup = () => {
       })
       .catch((err) => {
         console.log(`POST error:`, err);
-        toast.error(err.message);
+        // TODO: error messageごとにtoastのmessageを変える
+        toast.error("New account is not created.");
       });
   };
 

--- a/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
@@ -75,7 +75,10 @@ export const UserProfile: React.FC = () => {
       .then((_) => window.location.reload())
       .catch((err) => {
         console.log(`POST error:`, err);
-        toast.error(err.message);
+        toast.error("Balance cannot be negative");
+        // TODO:toastが出たあと、reloadしてもtoastが残るようにしたい
+      // }).finally(() => {
+      //   window.location.reload();
       });
   };
 
@@ -92,6 +95,9 @@ export const UserProfile: React.FC = () => {
             <div className="UserProfileInputs">
               <input
                 type="number"
+                // TODO:minusが入らないようにする
+                pattern="^[0-9]+$"
+                min="0"
                 name="balance"
                 id="MerTextInput"
                 placeholder="0"


### PR DESCRIPTION
Signupでinputが空だと登録できないように変更しました。

logは、

- nameがerrorの時、"Name is required"
- passwordがerrorの時、"Password is required"

とerror messageが出ますが、toastは全部error messageが同じなので、できれば修正したいです。